### PR TITLE
PDS-1395 updated exception to account for json api specs for errors

### DIFF
--- a/src/Exceptions/JsonApiException.php
+++ b/src/Exceptions/JsonApiException.php
@@ -3,11 +3,46 @@
 namespace Humi\JsonApiConnector\Exceptions;
 
 use Exception;
+use Throwable;
 
 class JsonApiException extends Exception
 {
+    protected string $errorTitle;
+    protected string $internalErrorCode;
+    protected array $meta;
+
+    public function __construct(
+        $message,
+        $code,
+        $errorTitle = null,
+        $internalCode = null,
+        $meta = [],
+        Throwable $throwable = null
+    )
+    {
+        parent::__construct($message, $code, $throwable);
+        $this->errorTitle = $errorTitle;
+        $this->internalErrorCode = $internalCode;
+        $this->meta = $meta;
+    }
+
     public function getErrors(): array
     {
         return json_decode($this->getMessage(), true)['errors'];
+    }
+
+    public function getErrorTitle()
+    {
+        return $this->errorTitle;
+    }
+
+    public function getInternalErrorCode()
+    {
+        return $this->internalErrorCode;
+    }
+
+    public function getMeta()
+    {
+        return $this->meta;
     }
 }

--- a/src/Exceptions/JsonApiException.php
+++ b/src/Exceptions/JsonApiException.php
@@ -14,10 +14,10 @@ class JsonApiException extends Exception
     public function __construct(
         $message,
         $code,
+        Throwable $throwable = null,
         $errorTitle = "",
         $internalCode = "",
-        $meta = [],
-        Throwable $throwable = null
+        $meta = []
     )
     {
         parent::__construct($message, $code, $throwable);

--- a/src/Exceptions/JsonApiException.php
+++ b/src/Exceptions/JsonApiException.php
@@ -14,8 +14,8 @@ class JsonApiException extends Exception
     public function __construct(
         $message,
         $code,
-        $errorTitle = null,
-        $internalCode = null,
+        $errorTitle = "",
+        $internalCode = "",
         $meta = [],
         Throwable $throwable = null
     )


### PR DESCRIPTION
Updating JSON API error response for when exceptions are extending this class on the HR repo. 

It is vague enough that it wouldn't change the way it is working currently but will give enough room to consolidate our responses with an approach that fulfills the [JSON API specs](https://jsonapi.org/format/#errors) for errors.

The reason for doing this is that we would like to structure our error responses to be more standardized as per [this document](https://gethumi.atlassian.net/wiki/spaces/PLAT/pages/1807384579/Error+Response).