### PR TITLE
chore: [OPS-4501] - bump action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     reviewers:
       - "avrahamappel-humi"
       - "Humi-HR/laravel"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -6,10 +6,10 @@ on:
 jobs:
   draft-release:
     name: "Draft Release"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
[Jira OPS-4501](https://gethumi.atlassian.net/browse/OPS-4501)

Currently this repository shows some warnings in the Annotations of the most recent workflow run, e.g.: https://github.com/Humi-HR/json-api-connector/actions/runs/4285775024

This PR attempts to resolve these by updating to newer versions of GitHub Actions where available. 
It also updates the Dependabot configuration to allow it to propose updates for the actions.