### PR TITLE
ci: [OPS-4501] - refactor unmaintained actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -24,6 +24,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.bump-semver.outputs.version_tag }}
-          name: ${{ steps.bump-semver.outputs.version_tag }}        
+          name: ${{ steps.bump-semver.outputs.version_tag }}
           draft: false
-          prerelease: false     
+          prerelease: false

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,25 +10,20 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-
-      - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: get-latest-tag
         with:
-          semver_only: true
+          fetch-depth: 0
 
-      - uses: actions-ecosystem/action-bump-semver@v1
+      - name: Bump SemVer
         id: bump-semver
-        with:
-          current_version: ${{ steps.get-latest-tag.outputs.tag }}
-          level: patch
+        uses: paulhatch/semantic-version@v5.3.0
+        with: 
+          tag_prefix: "v"
+          bump_each_commit: true
 
       - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          release_name: ${{ steps.bump-semver.outputs.new_version }}
-          tag_name: ${{ steps.bump-semver.outputs.new_version }}
+          tag_name: ${{ steps.bump-semver.outputs.version_tag }}
+          name: ${{ steps.bump-semver.outputs.version_tag }}        
           draft: false
-          prerelease: false
+          prerelease: false     


### PR DESCRIPTION
[Jira OPS-4501](https://gethumi.atlassian.net/browse/OPS-4501)

Currently this repository shows some warnings in the Annotations of the most recent workflow run, e.g.: https://github.com/Humi-HR/json-api-connector/actions/runs/4285775024

Some warnings stem from GitHub Actions which are not being maintained, and therefore will not get fixed. This PR migrates to new Actions which are maintained. 