### PR TITLE
chore: [OPS-4501] - bump version of semantic-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Bump SemVer
         id: bump-semver
-        uses: paulhatch/semantic-version@v5.3.0
+        uses: paulhatch/semantic-version@v5.4.0
         with: 
           tag_prefix: "v"
           bump_each_commit: true


### PR DESCRIPTION
[Jira OPS-4501](https://gethumi.atlassian.net/browse/OPS-4501)

Resolves a warning in the Annotations of the most recent workflow run, e.g.: https://github.com/Humi-HR/json-api-connector/actions/runs/8756296541

